### PR TITLE
Revise DOPSA for Dash for R v0.3.0

### DIFF
--- a/app.R
+++ b/app.R
@@ -2,14 +2,6 @@ library(dash)
 library(dashCoreComponents)
 library(dashHtmlComponents)
 
-appName <- Sys.getenv("DASH_APP_NAME")
-if (appName != "") {
-  pathPrefix <- sprintf("/%s/", appName)
-
-  Sys.setenv(DASH_ROUTES_PATHNAME_PREFIX = pathPrefix,
-             DASH_REQUESTS_PATHNAME_PREFIX = pathPrefix)
-}
-
 app <- Dash$new()
 
 app$layout(
@@ -51,8 +43,4 @@ app$callback(output(id = 'output-state', property = 'children'),
                sprintf("The Button has been pressed \"%s\" times, Input 1 is \"%s\", and Input 2 is \"%s\"", n_clicks, input1, input2)
              })
 
-if (appName != "") {
-  app$run_server(host = "0.0.0.0", port = Sys.getenv('PORT', 8050))
-} else {
-  app$run_server()
-}
+app$run_server()

--- a/init.R
+++ b/init.R
@@ -2,10 +2,6 @@
 # contains placeholders which are inserted by the compile script
 # NOTE: this script is executed in the chroot context; check paths!
 
-r <- getOption("repos")
-r["CRAN"] <- "http://cloud.r-project.org"
-options(repos=r)
-
 # ======================================================================
 
 # packages go here


### PR DESCRIPTION
I've modified `dashr-on-premise-sample-app` so that it should work with the new version of Dash for R as well as needed edits to the buildpack (which have since merged).