### PR TITLE
Get dashR package from CRAN

### DIFF
--- a/init.R
+++ b/init.R
@@ -5,4 +5,4 @@
 # ======================================================================
 
 # packages go here
-remotes::install_github("plotly/dashR", dependencies=TRUE, upgrade=TRUE)
+install.packages("dash")


### PR DESCRIPTION
Dash for R is now on CRAN :tada: 

This PR changes `init.R` to get it from CRAN instead of GitHub.

I got again the following error while working on https://github.com/plotly/streambed/issues/13838 even if I added a `GITHUB_PAT` to the CircleCI environment variables.

```
INFO     git_cmd:git_cmd.py:112 remote:        Error: Failed to install 'unknown package' from GitHub:        
remote:        HTTP error 403.        
remote:        API rate limit exceeded for 3.227.9.10. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)        
remote:                
remote:        Rate limit remaining: 0/60        
remote:        Rate limit reset at: 2020-06-15 22:36:29 UTC        
remote:                
remote:        To increase your GitHub API rate limit        
remote:        - Use `usethis::browse_github_pat()` to create a Personal Access Token.        
remote:        - Use `usethis::edit_r_environ()` and add the token as `GITHUB_PAT`.        
remote:        Execution halted        
remote:        ERROR: R 3.6.2 failed while executing "init". Check the log for details.
```

Instead of investigating why we still get throttled even with the environment variable added, I think we can simply get the package from CRAN.

I tested this by deploying the app with this change to a DE test instance.

@plotly/devops FYI

@rpkyle could you please review ?